### PR TITLE
Add optional dockerfile input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Name of the image. Should be specified without domain and project.
 
 Image tag to set for the built image.
 
+### `dockerfile`
+
+Optional path to the Dockerfile to build. Defaults to `Dockerfile`.
+
 ## Required Environment Variables
 
 ### `GCLOUD_SERVICE_KEY`
@@ -35,13 +39,15 @@ Project id. Used in combination with GCR endpoint to build full docker image.
 
 ## Example usage
 
-```ylm
+```yaml
 uses: raccoondev/push-docker-gcr
 with:
   gcr_host: eu.gcr.io
   image_name: my_image
   image_tag: latest
+  dockerfile: Dockerfile.base
   env:
     GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
     GOOGLE_PROJECT_ID: ${{ secrets.GOOGLE_PROJECT_ID }}
 ```
+

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,10 @@ inputs:
     description: 'the directory to look the docker file in'
     required: false
     default: '.'
+  dockerfile:
+    description: 'Dockerfile to use for build'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,5 +6,11 @@ echo -n $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https:/
 
 cd $INPUT_WORKING_DIR
 
-docker build -t $IMAGE_NAME .
+if [ -n "$INPUT_DOCKERFILE" ]; then
+  DOCKERFILE_ARG="-f $INPUT_DOCKERFILE"
+else
+  DOCKERFILE_ARG=""
+fi
+
+docker build $DOCKERFILE_ARG -t $IMAGE_NAME .
 docker push $IMAGE_NAME


### PR DESCRIPTION
## Summary
- document dockerfile input as optional
- update example code block formatting
- append missing newlines

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_b_685437c4dc3c832785d8e6a9d3d34549